### PR TITLE
Rétablissement boutons d'alerte

### DIFF
--- a/desktop/php/seniorcare.php
+++ b/desktop/php/seniorcare.php
@@ -250,6 +250,17 @@ $eqLogics = eqLogic::byType($plugin->getId());
       <br>
 -->
 
+        <form class="form-horizontal">
+        <fieldset>
+          <legend><i class="fas fa-toggle-on"></i> {{Boutons d'alerte immédiate (quel actionneur va lancer une alerte ?)}}
+            <a class="btn btn-success btn-sm addSensorBtAlert" style="margin:5px;"><i class="fas fa-plus-circle"></i> {{Ajouter un bouton}}</a>
+          </legend>
+          <div id="div_alert_bt"></div>
+        </fieldset>
+      </form>
+
+      <br>
+
       <form class="form-horizontal">
         <fieldset>
           <legend><i class="fas fa-bomb"></i> {{Actions alerte immédiate vers les aidants (pour alerter, je dois ?)}} <sup><i class="fas fa-question-circle tooltips" title="{{Actions réalisées à l'activation d'un bouton d'alerte par la personne dépendante.
@@ -265,7 +276,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
 
       <form class="form-horizontal">
         <fieldset>
-          <legend><i class="fas fa-toggle-off"></i> {{Boutons d'annulation d'alerte (quel actionneur pour couper l'alerte ?)}} <sup><i class="fas fa-question-circle tooltips" title="{{Bouton de déactivation d'alerte}}"></i></sup>
+          <legend><i class="fas fa-toggle-off"></i> {{Boutons d'annulation d'alerte (quel actionneur pour couper l'alerte ?)}} <sup><i class="fas fa-question-circle tooltips" title="{{Bouton de désactivation d'alerte}}"></i></sup>
             <a class="btn btn-success btn-sm addSensorCancelBtAlert" style="margin:5px;"><i class="fas fa-plus-circle"></i> {{Ajouter un bouton}}</a>
           </legend>
           <div id="div_cancel_alert_bt"></div>


### PR DESCRIPTION
En testant le plugin, je me suis rendu compte d'une faute que j'avais commis et, qu'au lieu de supprimer le tooltips du bouton d'alerte, j'avais complétement occulté cette saisie.
En fait, j'avais mis tout ce qui la concernait en commentaire en me disant que j'y repasserais plus tard et, comme de bien entendu, je n'y suis pas repassé. Du coup, plus de saisie de boutons d'alerte.
J'ai donc rétabli le code manquant..
Merci de vérifier si je n'ai pas commis d'erreur.
Et, au fait, aller à la ligne ne sert décidément à rien dans les tooltips, ça demeure inchangé et séquentiel.
A+